### PR TITLE
Add Shoelace as a style option for web projects.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,6 +10,7 @@
     "build": "1",
     "python_version": "3.X.0",
     "style_framework": [
+        "Shoelace v2.3",
         "Bootstrap v4.6",
         "None"
     ],

--- a/tests/apps/verify-toga/pyproject.toml
+++ b/tests/apps/verify-toga/pyproject.toml
@@ -17,7 +17,7 @@ requires = [
 
 [tool.briefcase.app.verify-toga.web]
 requires = [
-    'toga-web>=0.3.0.dev38'
+    'toga-web~=0.3.0'
 ]
-style_framework = "Bootstrap v4.6"
+style_framework = "Shoelace v2.3"
 template = '../../../'

--- a/{{ cookiecutter.format }}/www/index.html
+++ b/{{ cookiecutter.format }}/www/index.html
@@ -15,11 +15,15 @@
               href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"
               integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N"
               crossorigin="anonymous">
+{% elif cookiecutter.style_framework == "Shoelace v2.3" %}
+        <link rel="stylesheet"
+              href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/themes/light.css" />
+        <script type="module"
+                src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/shoelace-autoloader.js"></script>
 {% endif %}
         <link rel="stylesheet" href="/static/css/briefcase.css">
     </head>
-    <body>
-        <div id="app-placeholder"></div>
+    <body id="app-placeholder">
 {% if cookiecutter.style_framework == "Bootstrap v4.6" %}
         <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js"
                 integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"


### PR DESCRIPTION
Provide an option for Shoelace as a style framework for web projects.

Refs beeware/toga#1838
Refs beeware/briefcase-template#65

This adds an extra template option, but doesn't change the default, which should be no-op for any existing project.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
