### PR TITLE
Change Shoelace autoloader to traditional loader

### DIFF
--- a/{{ cookiecutter.format }}/www/index.html
+++ b/{{ cookiecutter.format }}/www/index.html
@@ -19,7 +19,7 @@
         <link rel="stylesheet"
               href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/themes/light.css" />
         <script type="module"
-                src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/shoelace-autoloader.js"></script>
+                src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/shoelace.js"></script>
 {% endif %}
         <link rel="stylesheet" href="/static/css/briefcase.css">
     </head>


### PR DESCRIPTION
I cannot reference Shoelace components from a pyodide context until those components have been loaded. However, I also cannot figure out how to programmatically eager load the components we need. So by just eager loading all components up front (which is the difference between the traditional loader and the lazy "autoloader"), we get all components ready immediately.  Load time for Toga apps in briefcase appears to spend most of its time in Python initialization and loading pyodide. Load time for Shoelace with this as opposed to the lazy loader appears to be negligible.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
  - To the best of my ability through manual testing while developing on Toga!
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
