### PR TITLE
Pin PyScript

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -20,5 +20,6 @@
     ],
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension"
-    ]
+    ],
+    "_jinja2_env_vars": {"lstrip_blocks": true, "trim_blocks": true}
 }

--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -1,4 +1,7 @@
 # Generated using Python {{ cookiecutter.python_version }}
+[briefcase]
+target_version = "0.3.21"
+
 [paths]
 app_path = "app"
 app_requirements_path = "requirements.txt"

--- a/{{ cookiecutter.format }}/www/index.html
+++ b/{{ cookiecutter.format }}/www/index.html
@@ -7,8 +7,8 @@
 
         <link rel="icon" type="image/png" href="/static/logo-32.png"/>
 
-        <script defer src="https://pyscript.net/latest/pyscript.js"></script>
-        <link rel="stylesheet" href="https://pyscript.net/latest/pyscript.css" />
+        <link rel="stylesheet" href="https://pyscript.net/releases/2024.10.1/core.css">
+        <script type="module" src="https://pyscript.net/releases/2024.10.1/core.js"></script>
 
 {% if cookiecutter.style_framework == "Bootstrap v4.6" %}
         <link rel="stylesheet"
@@ -32,10 +32,9 @@
                 integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
                 crossorigin="anonymous"></script>
 {% endif %}
-        <py-config src="/pyscript.toml"></py-config>
-        <py-script>
+        <script type="py" async="false" config="pyscript.toml">
             import runpy
             result = runpy.run_module("{{ cookiecutter.module_name }}", run_name="__main__", alter_sys=True)
-        </py-script>
+        </script>
     </body>
 </html>

--- a/{{ cookiecutter.format }}/www/index.html
+++ b/{{ cookiecutter.format }}/www/index.html
@@ -7,6 +7,14 @@
 
         <link rel="icon" type="image/png" href="/static/logo-32.png"/>
 
+        <script type="module">
+            // Hide the splash screen when the page is ready.
+            import { hooks } from "https://pyscript.net/releases/2024.10.1/core.js";
+            hooks.main.onReady.add(() => {
+                document.getElementById("briefcase-splash").classList.add("hidden");
+            });
+        </script>
+
         <link rel="stylesheet" href="https://pyscript.net/releases/2024.10.1/core.css">
         <script type="module" src="https://pyscript.net/releases/2024.10.1/core.js"></script>
 
@@ -24,6 +32,10 @@
         <link rel="stylesheet" href="/static/css/briefcase.css">
     </head>
     <body id="app-placeholder">
+        <div id="briefcase-splash">
+            <img src="static/logo-32.png" alt="Splash screen logo">
+            <p>Loading...</p>
+        </div>
 {% if cookiecutter.style_framework == "Bootstrap v4.6" %}
         <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js"
                 integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"

--- a/{{ cookiecutter.format }}/www/index.html
+++ b/{{ cookiecutter.format }}/www/index.html
@@ -9,14 +9,14 @@
 
         <script type="module">
             // Hide the splash screen when the page is ready.
-            import { hooks } from "https://pyscript.net/releases/2024.10.1/core.js";
+            import { hooks } from "https://pyscript.net/releases/2024.11.1/core.js";
             hooks.main.onReady.add(() => {
                 document.getElementById("briefcase-splash").classList.add("hidden");
             });
         </script>
 
-        <link rel="stylesheet" href="https://pyscript.net/releases/2024.10.1/core.css">
-        <script type="module" src="https://pyscript.net/releases/2024.10.1/core.js"></script>
+        <link rel="stylesheet" href="https://pyscript.net/releases/2024.11.1/core.css">
+        <script type="module" src="https://pyscript.net/releases/2024.11.1/core.js"></script>
 
 {% if cookiecutter.style_framework == "Bootstrap v4.6" %}
         <link rel="stylesheet"
@@ -46,7 +46,9 @@
 {% endif %}
         <script type="py" async="false" config="pyscript.toml">
             import runpy
-            result = runpy.run_module("{{ cookiecutter.module_name }}", run_name="__main__", alter_sys=True)
+            result = runpy.run_module(
+                "{{ cookiecutter.module_name }}", run_name="__main__", alter_sys=True
+            )
         </script>
     </body>
 </html>

--- a/{{ cookiecutter.format }}/www/pyscript.toml
+++ b/{{ cookiecutter.format }}/www/pyscript.toml
@@ -1,0 +1,1 @@
+plugins = ["!error"]

--- a/{{ cookiecutter.format }}/www/static/css/briefcase.css
+++ b/{{ cookiecutter.format }}/www/static/css/briefcase.css
@@ -1,5 +1,5 @@
 
-/* Make error content invisible */
+/* Prevent stderr appearing on the page. It will still be visible in the console. */
 div.py-error {
     display: none;
 }

--- a/{{ cookiecutter.format }}/www/static/css/briefcase.css
+++ b/{{ cookiecutter.format }}/www/static/css/briefcase.css
@@ -1,9 +1,3 @@
-
-/* Prevent stderr appearing on the page. It will still be visible in the console. */
-div.py-error {
-    display: none;
-}
-
 /* Splash screen */
 div#briefcase-splash {
     background-color:#999;

--- a/{{ cookiecutter.format }}/www/static/css/briefcase.css
+++ b/{{ cookiecutter.format }}/www/static/css/briefcase.css
@@ -29,6 +29,20 @@ div#briefcase-splash.hidden {
     opacity: 0;
     transition: visibility 0s 0.2s, opacity 0.2s linear;
 }
+div#briefcase-splash img {
+    animation: throbber 1.5s infinite;
+}
+@keyframes throbber {
+    0% {
+        transform: scale(1.2);
+    }
+    70% {
+        transform: scale(1.0);
+    }
+    100% {
+        transform: scale(1.2);
+    }
+}
 
 /*******************************************************************
  * WARNING: Do not remove or modify this comment block, or add any

--- a/{{ cookiecutter.format }}/www/static/css/briefcase.css
+++ b/{{ cookiecutter.format }}/www/static/css/briefcase.css
@@ -1,15 +1,33 @@
 
-/* Unset the overly generic pyscript .label style */
-#app-placeholder .label {
-    margin-top: inherit;
-    color: inherit;
-    text-align: inherit;
-    width: inherit;
-    display: inherit;
-    color: inherit;
-    font-size: inherit;
-    margin-top: inherit;
+/* Make error content invisible */
+div.py-error {
+    display: none;
+}
 
+/* Splash screen */
+div#briefcase-splash {
+    background-color:#999;
+    position:fixed;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width:100%;
+    height:100%;
+    top:0px;
+    left:0px;
+    z-index:1000;
+}
+div#briefcase-splash p {
+    text-align: center;
+    color: white;
+    font-size: large;
+    font-family: sans-serif;
+}
+div#briefcase-splash.hidden {
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 0s 0.2s, opacity 0.2s linear;
 }
 
 /*******************************************************************


### PR DESCRIPTION
## Changes
- PyScript deprecated `latest` and requires pinning for newer versions
- `<py-script>` can just be `<script type="py">` now
- PyScript now enables a top-level loop by default; I added `async="false"` to disable it
- `<py-config>` isn't necessary since it can be specified via `<script type="py" config="pyscript.toml">`

## Notes
- I think that ideally the PyScript version would live in Briefcase...or via the method I'm working on in https://github.com/beeware/briefcase/pull/1943. But I'll leave that to future work I think
- I can't figure out a good method to stop Toga's warnings from showing in the page content
  - Although, adding `import warnings; warnings.filterwarnings("ignore")` to `index.html` technically works....

BRIEFCASE_REPO: https://github.com/mhsmith/briefcase
BRIEFCASE_REF: pyscript-2024.11.1

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
