### PR TITLE
Implement insert injection system for HTML and CSS (Phase 3)

### DIFF
--- a/{{ cookiecutter.format }}/www/index.html
+++ b/{{ cookiecutter.format }}/www/index.html
@@ -27,19 +27,11 @@
         <link rel="stylesheet" href="https://pyscript.net/releases/2024.11.1/core.css">
         <script type="module" src="https://pyscript.net/releases/2024.11.1/core.js"></script>
 
-        <!-- App Style -->
+        <!-- Toolkit Style Insert -->
 
-{% if cookiecutter.style_framework == "Bootstrap v4.6" %}
-        <link rel="stylesheet"
-              href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"
-              integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N"
-              crossorigin="anonymous">
-{% elif cookiecutter.style_framework == "Shoelace v2.3" %}
-        <link rel="stylesheet"
-              href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/themes/light.css" />
-        <script type="module"
-                src="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/shoelace.js"></script>
-{% endif %}
+        <!--@@ header:start @@-->
+        <!--@@ header:end @@-->
+
         <link rel="stylesheet" href="/static/css/briefcase.css">
     </head>
     <body id="app-placeholder">
@@ -47,14 +39,7 @@
             <img src="static/logo-32.png" alt="Splash screen logo">
             <p>Loading...</p>
         </div>
-{% if cookiecutter.style_framework == "Bootstrap v4.6" %}
-        <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js"
-                integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
-                crossorigin="anonymous"></script>
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
-                integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
-                crossorigin="anonymous"></script>
-{% endif %}
+
         <script type="py" async="false" config="pyscript.toml">
             import runpy
             result = runpy.run_module(

--- a/{{ cookiecutter.format }}/www/static/css/briefcase.css
+++ b/{{ cookiecutter.format }}/www/static/css/briefcase.css
@@ -38,12 +38,12 @@ div#briefcase-splash img {
     }
 }
 
+/*******************************************************************
+ * WARNING: Do not remove or modify this comment block, or add any
+ * content below this block, including anything between the CSS
+ * markers. Briefcase will add content here during the build step.
+ ******************* Wheel contributed styles **********************/
+
 /************************* Toolkit styles *************************/
 /*@@ style:start @@*/
 /*@@ style:end @@*/
-
-/*******************************************************************
- * WARNING: Do not remove or modify this comment block, or add any
- * content below this block. Briefcase will add content here during
- * the build step.
- ******************* Wheel contributed styles **********************/

--- a/{{ cookiecutter.format }}/www/static/css/briefcase.css
+++ b/{{ cookiecutter.format }}/www/static/css/briefcase.css
@@ -38,6 +38,10 @@ div#briefcase-splash img {
     }
 }
 
+/************************* Toolkit styles *************************/
+/*@@ style:start @@*/
+/*@@ style:end @@*/
+
 /*******************************************************************
  * WARNING: Do not remove or modify this comment block, or add any
  * content below this block. Briefcase will add content here during

--- a/{{ cookiecutter.format }}/www/static/css/briefcase.css
+++ b/{{ cookiecutter.format }}/www/static/css/briefcase.css
@@ -45,5 +45,5 @@ div#briefcase-splash img {
  ******************* Wheel contributed styles **********************/
 
 /************************* Toolkit styles *************************/
-/*@@ style:start @@*/
-/*@@ style:end @@*/
+/***@@ CSS:start @@***/
+/***@@ CSS:end @@***/


### PR DESCRIPTION
This PR implements Phase 3 of this [deliverable](https://github.com/beeware/briefcase/issues/2337). It introduces support for reading and injecting insert content from GUI toolkit wheels into HTML and CSS templates using predefined insert markers.

This allows GUI toolkits such as Toga to inject their own scripts and styles into the template using insert markers, removing hardcoded dependencies from Briefcase.

Refs beeware/briefcase#2337

## PR Checklist:
- [ x ] All new features have been tested
- [ x ] All new features have been documented
- [ x ] I have read the **CONTRIBUTING.md** file
- [ x ] I will abide by the code of conduct